### PR TITLE
update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV SPARK_HOME=/usr/spark/spark-2.1.0-bin-hadoop2.7 \
 
 RUN mkdir /usr/spark && \
     curl -sL --retry 3 \
-    "http://apache.mirror.serversaustralia.com.au/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.7.tgz" \
+    "https://archive.apache.org/dist/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.7.tgz" \
     | gzip -d \
     | tar x -C /usr/spark && \
     chown -R root:root $SPARK_HOME


### PR DESCRIPTION
fix the error source url for spark-2.1.0 (line 21)
The link appeared to be dead. 